### PR TITLE
[#28/fix] 유튜브 썸네일 이미지 개선

### DIFF
--- a/src/event_calendar/serializers/calendar_serializer.py
+++ b/src/event_calendar/serializers/calendar_serializer.py
@@ -59,7 +59,7 @@ class UpdateCalendarCardSerializer(serializers.ModelSerializer):
     youtube_video_id = serializers.CharField(source="youtube.video_id", allow_null=True, allow_blank=True)
     youtube_thumbnail_link = serializers.URLField(source="youtube.thumbnail_url", write_only=True)
     calendar_thumbnail = serializers.SerializerMethodField()
-    thumbnail_file = serializers.ImageField(use_url=True, write_only=True)
+    thumbnail_file = serializers.ImageField(allow_null=True, required=False, use_url=True, write_only=True)
 
     @staticmethod
     def get_calendar_thumbnail(obj):

--- a/src/event_calendar/serializers/calendar_serializer.py
+++ b/src/event_calendar/serializers/calendar_serializer.py
@@ -101,14 +101,12 @@ class UpdateCalendarCardSerializer(serializers.ModelSerializer):
                     youtube_thumbnail = youtube_thumbnail.replace("maxresdefault", "hqdefault")
 
                 instance.youtube.thumbnail_url = youtube_thumbnail
-
             if youtube_video_id != instance.youtube.video_id and youtube_video_id:
                 instance.youtube.video_id = youtube_video_id
 
             instance.youtube.save()
 
-        if thumbnail_file:
-            instance.thumbnail_file = thumbnail_file
+        instance.thumbnail_file = thumbnail_file
 
         for attr, value in validated_data.items():
             if attr not in ["youtube_thumbnail", "thumbnail_file"]:

--- a/src/event_calendar/serializers/calendar_serializer.py
+++ b/src/event_calendar/serializers/calendar_serializer.py
@@ -46,6 +46,7 @@ class CalendarCardSerializer(serializers.ModelSerializer):
             "comment_detail",
             "youtube_video_id",
             "calendar_thumbnail",
+            "thumbnail_file",
         ]
 
 

--- a/src/event_calendar/serializers/calendar_serializer.py
+++ b/src/event_calendar/serializers/calendar_serializer.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 
 from event_calendar.models import EventCalendar
 from guest_book.serializers.guest_book_serializer import GuestBookSerializer
+from utils.event_calendar.youtube_thumbnail_image import get_youtube_thumbnail_image_size
 
 
 class CalendarCardSerializer(serializers.ModelSerializer):
@@ -89,8 +90,15 @@ class UpdateCalendarCardSerializer(serializers.ModelSerializer):
 
         thumbnail_file = validated_data.get("thumbnail_file")
 
+        # NOTE: 유튜브 썸네일 이미지를 입력 하였거나 유튜브 비디오 아이디를 입력 한 경우
         if youtube_thumbnail or youtube_video_id:
             if youtube_thumbnail != instance.youtube.thumbnail_url and youtube_thumbnail:
+                youtube_thumbnail_size = get_youtube_thumbnail_image_size(youtube_thumbnail)
+
+                # NOTE: default thumbnail size가 120, 90 일 때 저장 하지 않음
+                if youtube_thumbnail_size.is_invalid_image_size():
+                    youtube_thumbnail = youtube_thumbnail.replace("maxresdefault", "hqdefault")
+
                 instance.youtube.thumbnail_url = youtube_thumbnail
 
             if youtube_video_id != instance.youtube.video_id and youtube_video_id:

--- a/src/utils/event_calendar/youtube_thumbnail_image.py
+++ b/src/utils/event_calendar/youtube_thumbnail_image.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass
+from io import BytesIO
+from typing import Optional
+
+import requests
+from PIL import Image
+
+
+@dataclass
+class YoutubeThumbnailImageSize:
+    width: int
+    height: int
+
+    def is_invalid_image_size(self):
+        return self.width == 120 and self.height == 90
+
+
+def get_youtube_thumbnail_image_size(youtube_thumbnail_url: Optional[str]) -> YoutubeThumbnailImageSize:
+    """
+    유튜브 썸네일 이미지의 사이즈 추출
+    :param youtube_thumbnail_url: 유튜브 썸네일에서 제공 하는 이미지 링크
+    :return: Tuple[width, height]
+    """
+
+    if not youtube_thumbnail_url:
+        raise ValueError("must be have youtube thumbnail url")
+
+    res = requests.get(youtube_thumbnail_url)
+    youtube_thumbnail_url_image = Image.open(BytesIO(res.content))
+    return YoutubeThumbnailImageSize(*youtube_thumbnail_url_image.size)


### PR DESCRIPTION
# ✨ Make a Pull Request

## 코드 변경 사항 제출

### 제목
유튜브 썸네일 이미지 개선

### 변경 유형
코드 변경의 유형을 선택 해주세요.

- [ ] 📄 문서 업데이트 (Documentation Update)
- [X] 🔧 기능 개선 (Enhancement)
- [ ] 🆕 신규 기능 추가 (New Feature)
- [ ] 🐞 버그 수정 (Bug Fix)
- [ ] 💡 리팩토링 (Refactoring)
- [ ] 🧪 테스트 추가/수정 (Test)


### 변경 사항 설명
1. 유튜브 썸네일이 깨지면서 기본 스켈레톤 이미지를 제공 할 때 다른 화질의 썸네일 이미지로 교체합니다.
2. 캘린더 카드를 업데이트 할 때 사용자가 원하는 썸네일 이미지를 Optional로 요청 받습니다.
3. 사용자가 원하는 썸네일 이미지를 `None` 으로 입력 하는 경우 해당 썸네일 파일을 삭제 하고 그 전에 사용되던 이미지를 보여줍니다.
4. 캘린더 리스트 전체를 조회 할 때 앞으로 사용자의 썸네일 파일을 같이 보여줍니다.

### 참고 자료
변경 사항에 대해 추가로 설명 하거나 참고 할 자료가 있다면 첨부 해주세요.
_No Response_




### :clipboard: 제출 전 체크리스트
제출 전에 다음 사항들을 확인해주세요.

- [X] 변경 사항이 테스트되었으며, 문제없음을 확인함
- [x] 관련된 Issue 번호를 정확히 연결 함
- [X] 변경 사항에 필요한 라벨을 추가함 (Labels 설정)